### PR TITLE
[Client] upload profile 

### DIFF
--- a/packages/api/client/src/hooks/student/index.ts
+++ b/packages/api/client/src/hooks/student/index.ts
@@ -1,1 +1,2 @@
 export * from './useGetStudentInfo';
+export * from './usePostUploadProfile';

--- a/packages/api/client/src/hooks/student/usePostUploadProfile.ts
+++ b/packages/api/client/src/hooks/student/usePostUploadProfile.ts
@@ -1,0 +1,16 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { post, uploadQueryKey, uploadUrl } from 'api/common';
+
+import { UploadProfileType } from 'types';
+
+import type { UseMutationOptions } from '@tanstack/react-query';
+
+export const usePostUploadProfile = (
+  options?: UseMutationOptions<UploadProfileType>
+) =>
+  useMutation<UploadProfileType>(
+    uploadQueryKey.postUploadProfile(),
+    (uploadProfile) => post(uploadUrl.uploadProfile(), uploadProfile),
+    options
+  );

--- a/packages/api/client/src/hooks/student/usePostUploadProfile.ts
+++ b/packages/api/client/src/hooks/student/usePostUploadProfile.ts
@@ -1,16 +1,9 @@
 import { useMutation } from '@tanstack/react-query';
 
-import { post, uploadQueryKey, uploadUrl } from 'api/common';
+import { post, studentQueryKeys, studentUrl } from 'api/common';
 
-import { UploadProfileType } from 'types';
-
-import type { UseMutationOptions } from '@tanstack/react-query';
-
-export const usePostUploadProfile = (
-  options?: UseMutationOptions<UploadProfileType>
-) =>
-  useMutation<UploadProfileType>(
-    uploadQueryKey.postUploadProfile(),
-    (uploadProfile) => post(uploadUrl.uploadProfile(), uploadProfile),
-    options
+export const usePostUploadProfile = () =>
+  useMutation<void, Error, { image: FormData }>(
+    studentQueryKeys.postUploadProfile(),
+    (uploadProfile) => post(studentUrl.uploadProfile(), uploadProfile)
   );

--- a/packages/api/client/src/hooks/student/usePostUploadProfile.ts
+++ b/packages/api/client/src/hooks/student/usePostUploadProfile.ts
@@ -3,10 +3,12 @@ import { useMutation } from '@tanstack/react-query';
 import { post, studentQueryKeys, studentUrl } from 'api/common';
 
 export const usePostUploadProfile = () =>
-  useMutation(studentQueryKeys.postUploadProfile(), (uploadProfile: FormData) =>
-    post(studentUrl.uploadProfile(), uploadProfile, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    })
+  useMutation<{ imageName: string }, Error, { image: FormData }>(
+    studentQueryKeys.postUploadProfile(),
+    (uploadProfile) =>
+      post(studentUrl.uploadProfile(), uploadProfile, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      })
   );

--- a/packages/api/client/src/hooks/student/usePostUploadProfile.ts
+++ b/packages/api/client/src/hooks/student/usePostUploadProfile.ts
@@ -3,7 +3,10 @@ import { useMutation } from '@tanstack/react-query';
 import { post, studentQueryKeys, studentUrl } from 'api/common';
 
 export const usePostUploadProfile = () =>
-  useMutation<void, Error, { image: FormData }>(
-    studentQueryKeys.postUploadProfile(),
-    (uploadProfile) => post(studentUrl.uploadProfile(), uploadProfile)
+  useMutation(studentQueryKeys.postUploadProfile(), (uploadProfile: FormData) =>
+    post(studentUrl.uploadProfile(), uploadProfile, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    })
   );

--- a/packages/api/common/src/libs/queryKeys.ts
+++ b/packages/api/common/src/libs/queryKeys.ts
@@ -33,3 +33,7 @@ export const orderQueryKeys = {
   getOrderedItemList: () => ['order', 'list'],
   patchOrderStatus: (orderId: string) => ['order', 'status', orderId],
 };
+
+export const uploadQueryKey = {
+  postUploadProfile: () => ['upload', 'profile'],
+};

--- a/packages/api/common/src/libs/queryKeys.ts
+++ b/packages/api/common/src/libs/queryKeys.ts
@@ -7,6 +7,7 @@ export const missionQueryKeys = {
 export const studentQueryKeys = {
   getRankingList: () => ['student', 'rankingList'],
   getStudentInfo: () => ['student', 'info'],
+  postUploadProfile: () => ['upload', 'profile'],
 };
 
 export const authQueryKeys = {
@@ -32,8 +33,4 @@ export const orderQueryKeys = {
   postItem: () => ['order'],
   getOrderedItemList: () => ['order', 'list'],
   patchOrderStatus: (orderId: string) => ['order', 'status', orderId],
-};
-
-export const uploadQueryKey = {
-  postUploadProfile: () => ['upload', 'profile'],
 };

--- a/packages/api/common/src/libs/urlController.ts
+++ b/packages/api/common/src/libs/urlController.ts
@@ -6,6 +6,7 @@ export const missionUrl = {
 export const studentUrl = {
   rankingList: () => `/student/ranking`,
   studentInfo: () => `/student/my`,
+  uploadProfile: () => `/image`,
 };
 
 export const authUrl = {
@@ -28,8 +29,4 @@ export const itemUrl = {
 
 export const orderUrl = {
   orderItem: () => `/order`,
-};
-
-export const uploadUrl = {
-  uploadProfile: () => `/image`,
 };

--- a/packages/api/common/src/libs/urlController.ts
+++ b/packages/api/common/src/libs/urlController.ts
@@ -6,7 +6,7 @@ export const missionUrl = {
 export const studentUrl = {
   rankingList: () => `/student/ranking`,
   studentInfo: () => `/student/my`,
-  uploadProfile: () => `/image`,
+  uploadProfile: () => `/student/image`,
 };
 
 export const authUrl = {

--- a/packages/api/common/src/libs/urlController.ts
+++ b/packages/api/common/src/libs/urlController.ts
@@ -29,3 +29,7 @@ export const itemUrl = {
 export const orderUrl = {
   orderItem: () => `/order`,
 };
+
+export const uploadUrl = {
+  uploadProfile: () => `/image`,
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -8,4 +8,4 @@ export * from './scoringListType';
 export * from './solveStatusType';
 export * from './missionDetail';
 export * from './studentType';
-
+export * from './uploadProfile';

--- a/packages/types/src/uploadProfile.ts
+++ b/packages/types/src/uploadProfile.ts
@@ -1,4 +1,3 @@
 export interface UploadProfileType {
-  image: 'Multipart';
-  fileName: string;
+  image: FormData;
 }

--- a/packages/types/src/uploadProfile.ts
+++ b/packages/types/src/uploadProfile.ts
@@ -1,3 +1,4 @@
 export interface UploadProfileType {
   image: 'Multipart';
+  fileName: string;
 }

--- a/packages/types/src/uploadProfile.ts
+++ b/packages/types/src/uploadProfile.ts
@@ -1,0 +1,3 @@
+export interface UploadProfileType {
+  image: 'Multipart';
+}

--- a/projects/client/next.config.js
+++ b/projects/client/next.config.js
@@ -10,6 +10,9 @@ const nextConfig = {
       destination: `${process.env.NEXT_PUBLIC_API_URL}/:path*`,
     },
   ],
+  images: {
+    domains: ['https://stack-knowledge.s3.ap-northeast-2.amazonaws.com'],
+  },
 };
 
 module.exports = nextConfig;

--- a/projects/client/src/PageContainer/RankingPage/index.tsx
+++ b/projects/client/src/PageContainer/RankingPage/index.tsx
@@ -1,17 +1,22 @@
 'use client';
 
+import * as S from './style';
+
 import { RankingList } from 'common';
 
 import { RankingHeader } from 'client/components';
-import * as S from './style';
 
-const RankingPage = () => (
-  <S.RankingWrapper>
-    <div>
-      {/* <RankingHeader data={rankingData.data} ranking={rankingData.ranking} /> */}
-    </div>
-    <RankingList />
-  </S.RankingWrapper>
-);
+import { useGetStudentInfo } from 'api/client';
+
+const RankingPage = () => {
+  const { data } = useGetStudentInfo();
+
+  return (
+    <S.RankingWrapper>
+      {data && <RankingHeader data={data} ranking={data.cumulatePoint} />}
+      <RankingList />
+    </S.RankingWrapper>
+  );
+};
 
 export default RankingPage;

--- a/projects/client/src/PageContainer/RankingPage/index.tsx
+++ b/projects/client/src/PageContainer/RankingPage/index.tsx
@@ -18,7 +18,7 @@ const RankingPage = () => {
   }
 
   const userRanking =
-    rankingList.findIndex((item) => item.id === studentInfo.user.id) + 2;
+    rankingList.findIndex((item) => item.id === studentInfo.id) + 1;
 
   return (
     <S.RankingWrapper>

--- a/projects/client/src/PageContainer/RankingPage/index.tsx
+++ b/projects/client/src/PageContainer/RankingPage/index.tsx
@@ -7,13 +7,24 @@ import { RankingList } from 'common';
 import { RankingHeader } from 'client/components';
 
 import { useGetStudentInfo } from 'api/client';
+import { useGetRankingList } from 'api/common';
 
 const RankingPage = () => {
-  const { data } = useGetStudentInfo();
+  const { data: studentInfo } = useGetStudentInfo();
+  const { data: rankingList } = useGetRankingList();
+
+  if (!studentInfo || !rankingList) {
+    return null;
+  }
+
+  const userRanking =
+    rankingList.findIndex((item) => item.id === studentInfo.user.id) + 2;
 
   return (
     <S.RankingWrapper>
-      {data && <RankingHeader data={data} ranking={data.cumulatePoint} />}
+      {studentInfo && (
+        <RankingHeader data={studentInfo} ranking={userRanking} />
+      )}
       <RankingList />
     </S.RankingWrapper>
   );

--- a/projects/client/src/components/RankingHeader/index.tsx
+++ b/projects/client/src/components/RankingHeader/index.tsx
@@ -24,7 +24,11 @@ const RankingHeader: React.FC<RankingHeaderProps> = ({
   return (
     <S.RankingHeaderWrapper>
       <S.ProfileImageWrapper>
-        <Image fill alt='profile' src={profileImage ?? DefaultProfile} />
+        <Image
+          fill
+          alt='profile'
+          src={profileImage === '' ? DefaultProfile : profileImage}
+        />
       </S.ProfileImageWrapper>
       <S.UserContentWrapper>
         <S.UserRank>현재 {ranking}위</S.UserRank>

--- a/projects/client/src/components/RankingHeader/index.tsx
+++ b/projects/client/src/components/RankingHeader/index.tsx
@@ -22,24 +22,11 @@ const RankingHeader: React.FC<RankingHeaderProps> = ({
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files && e.target.files[0];
-    if (file) {
-      try {
-        uploadImageToServer(file);
-        alert('이미지 업로드가 완료되었습니다.');
-      } catch (error) {
-        console.error('Error uploading image:', error);
-        alert('이미지 업로드에 실패했습니다.');
-      }
+    if (e.target.files) {
+      const formData = new FormData();
+      formData.append('file', e.target.files[0], e.target.files[0].name);
+      mutate(formData);
     }
-  };
-
-  const uploadImageToServer = async (image: File) => {
-    console.log(image);
-    const formData = new FormData();
-    formData.append('image', image);
-
-    mutate({ image: formData });
   };
 
   return (

--- a/projects/client/src/components/RankingHeader/index.tsx
+++ b/projects/client/src/components/RankingHeader/index.tsx
@@ -18,16 +18,33 @@ const RankingHeader: React.FC<RankingHeaderProps> = ({
     user: { name, profileImage },
   },
 }) => {
-  const { mutate } = usePostUploadProfile();
+  const { mutate, isSuccess } = usePostUploadProfile();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) {
       const formData = new FormData();
       formData.append('file', e.target.files[0], e.target.files[0].name);
-      mutate(formData);
+      mutate({ image: formData });
+      // for (let value of formData.values()) {
+      //   console.log(value);
+      // }
+      //   await fetch('/api/student/image', {
+      //     method: 'POST',
+      //     headers: {
+      //       'Content-Type': 'multipart/form-data',
+      //     },
+      //     body: {
+      //       image: formData,
+      //     },
+      //   })
+      //     .then((res) => res.json())
+      //     .then((data) => console.log(data));
     }
   };
+
+  if (isSuccess) {
+  }
 
   return (
     <S.RankingHeaderWrapper>

--- a/projects/client/src/components/RankingHeader/index.tsx
+++ b/projects/client/src/components/RankingHeader/index.tsx
@@ -39,15 +39,7 @@ const RankingHeader: React.FC<RankingHeaderProps> = ({
     const formData = new FormData();
     formData.append('image', image);
 
-    try {
-      mutate((data) => {
-        console.log('asdasdasd');
-        return { ...data, image: formData };
-      });
-    } catch (error) {
-      alert('실패');
-      console.error('Error uploading image:', error);
-    }
+    mutate({ image: formData });
   };
 
   return (

--- a/projects/client/src/components/RankingHeader/index.tsx
+++ b/projects/client/src/components/RankingHeader/index.tsx
@@ -1,17 +1,14 @@
-'use client';
-
-import * as S from './style';
-
+import React, { useRef } from 'react';
+import Image from 'next/image';
+import { usePostUploadProfile } from 'api/client';
 import DefaultProfile from 'common/assets/svg/DefaultProfile.svg';
+import * as S from './style';
+import { RankingPropsType } from 'types';
 import { slicePoint } from 'common';
 
-import { RankingPropsType } from 'types';
-
-import Image from 'next/image';
-
 interface RankingHeaderProps {
-  data: RankingPropsType;
   ranking: number;
+  data: RankingPropsType;
 }
 
 const RankingHeader: React.FC<RankingHeaderProps> = ({
@@ -21,10 +18,50 @@ const RankingHeader: React.FC<RankingHeaderProps> = ({
     user: { name, profileImage },
   },
 }) => {
+  const { mutate } = usePostUploadProfile();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files && e.target.files[0];
+    if (file) {
+      try {
+        uploadImageToServer(file);
+        alert('이미지 업로드가 완료되었습니다.');
+      } catch (error) {
+        console.error('Error uploading image:', error);
+        alert('이미지 업로드에 실패했습니다.');
+      }
+    }
+  };
+
+  const uploadImageToServer = async (image: File) => {
+    console.log(image);
+    const formData = new FormData();
+    formData.append('image', image);
+
+    try {
+      mutate((data) => {
+        console.log('asdasdasd');
+        return { ...data, image: formData };
+      });
+    } catch (error) {
+      alert('실패');
+      console.error('Error uploading image:', error);
+    }
+  };
+
   return (
     <S.RankingHeaderWrapper>
-      <S.ProfileImageWrapper>
+      <S.ProfileImageWrapper onClick={() => fileInputRef.current?.click()}>
+        <input
+          type='file'
+          accept='image/*'
+          style={{ display: 'none' }}
+          ref={fileInputRef}
+          onChange={handleImageChange}
+        />
         <Image
+          key={profileImage}
           fill
           alt='profile'
           src={profileImage === '' ? DefaultProfile : profileImage}

--- a/projects/client/src/components/RankingHeader/style.ts
+++ b/projects/client/src/components/RankingHeader/style.ts
@@ -13,7 +13,7 @@ export const ProfileImageWrapper = styled.div`
   height: 7.5rem;
   overflow: hidden;
   position: relative;
-  right: 0.5rem;
+  right: 1.3rem;
   border-radius: 6.25rem;
   background-color: rgba(143, 143, 143, 1);
 
@@ -37,7 +37,7 @@ export const ProfileImageWrapper = styled.div`
 
 export const UserContentWrapper = styled.div`
   display: flex;
-  width: 21.875rem;
+  width: 16.875rem;
 `;
 
 export const UserRank = styled.div`
@@ -45,6 +45,7 @@ export const UserRank = styled.div`
   ${({ theme }) => theme.typo.button};
   padding-right: 0.625rem;
 `;
+
 export const UserName = styled.div`
   color: ${({ theme }) => theme.color.black};
   ${({ theme }) => theme.typo.button};

--- a/projects/client/src/components/RankingHeader/style.ts
+++ b/projects/client/src/components/RankingHeader/style.ts
@@ -37,6 +37,7 @@ export const ProfileImageWrapper = styled.div`
 
 export const UserContentWrapper = styled.div`
   display: flex;
+  width: 350px;
 `;
 
 export const UserRank = styled.div`

--- a/projects/client/src/components/RankingHeader/style.ts
+++ b/projects/client/src/components/RankingHeader/style.ts
@@ -37,7 +37,7 @@ export const ProfileImageWrapper = styled.div`
 
 export const UserContentWrapper = styled.div`
   display: flex;
-  width: 350px;
+  width: 21.875rem;
 `;
 
 export const UserRank = styled.div`


### PR DESCRIPTION
## 개요 💡

> PR의 개요를 작성.
ranking page에서 프로필 이미지 업로드 기능을 구현하였습니다.

## 작업내용 ⌨️
![](https://cdn.discordapp.com/attachments/956190154454876183/1158238465973026827/image.png?ex=651b8521&is=651a33a1&hm=18e0017da857685a7684bd25297d3e6a55858446d4e74b3edb7f65375c0d1bf7&)

> + 추가적인 내용으로 랭킹 표시를 학생 전체 리스트와 내 정보를 조합하여서 랭킹을 나타내는 것으로 하였습니다. (이슈 : index 시작이 0이라 + 1 이면 1등이라고 뜨는데  + 2를 해야지 2등이라고 뜹니다. )

## 관련 issue 🤯

> 서버에 FileName으로 respone 받아온 데이터 값을 사용해서 이미지 업로딩이 안되고 있습니다.
