### PR TITLE
http status exception

### DIFF
--- a/packages/api/common/src/libs/api/instance.ts
+++ b/packages/api/common/src/libs/api/instance.ts
@@ -30,7 +30,10 @@ apiInstance.interceptors.response.use(
     return Promise.reject(response.data);
   },
   async (error) => {
-    if (error.config.url === authUrl.auth() && error.response.status === 404) {
+    if (
+      error.config.url === authUrl.auth() &&
+      (error.response.status === 404 || error.response.status === 403)
+    ) {
       location.replace('/auth/login');
 
       return Promise.reject(error);


### PR DESCRIPTION
## 개요 💡

> http상태코드로 하는 예외처리를 수정했습니다.

응답 상태 코드가 403일 때에도 리다이렉트가 됩니다.
