### PR TITLE
[Common] Header Responsive

### DIFF
--- a/packages/common/src/PageContainer/MainPage/index.tsx
+++ b/packages/common/src/PageContainer/MainPage/index.tsx
@@ -14,7 +14,6 @@ const MainPage: React.FC<MainPageProps> = ({ isClient }) => {
       <S.MissionAlertText>
         * 문제는 12:30 ~ 19:30분까지 풀 수 있습니다.
       </S.MissionAlertText>
-      <MainContents isClient={isClient} />
     </S.MainWrapper>
   );
 };

--- a/packages/common/src/PageContainer/MainPage/index.tsx
+++ b/packages/common/src/PageContainer/MainPage/index.tsx
@@ -14,6 +14,7 @@ const MainPage: React.FC<MainPageProps> = ({ isClient }) => {
       <S.MissionAlertText>
         * 문제는 12:30 ~ 19:30분까지 풀 수 있습니다.
       </S.MissionAlertText>
+      <MainContents isClient={isClient} />
     </S.MainWrapper>
   );
 };

--- a/packages/common/src/assets/svg/HomeIcon.tsx
+++ b/packages/common/src/assets/svg/HomeIcon.tsx
@@ -1,7 +1,7 @@
 const HomeIcon = () => (
   <svg
-    width='26'
-    height='22'
+    width='1.625rem'
+    height='1.375rem'
     viewBox='0 0 26 22'
     fill='none'
     xmlns='http://www.w3.org/2000/svg'

--- a/packages/common/src/assets/svg/LogoIcon.tsx
+++ b/packages/common/src/assets/svg/LogoIcon.tsx
@@ -1,7 +1,7 @@
 const LogoIcon = () => (
   <svg
-    width='40'
-    height='40'
+    width='2.5rem'
+    height='2.5rem'
     viewBox='0 0 40 40'
     fill='none'
     xmlns='http://www.w3.org/2000/svg'

--- a/packages/common/src/assets/svg/QuestionIcon.tsx
+++ b/packages/common/src/assets/svg/QuestionIcon.tsx
@@ -1,7 +1,7 @@
 const QuestionIcon = () => (
   <svg
-    width='20'
-    height='22'
+    width='1.25rem'
+    height='1.375rem'
     viewBox='0 0 20 22'
     fill='none'
     xmlns='http://www.w3.org/2000/svg'

--- a/packages/common/src/assets/svg/RankingIcon.tsx
+++ b/packages/common/src/assets/svg/RankingIcon.tsx
@@ -1,7 +1,7 @@
 const RankingIcon = () => (
   <svg
-    width='18'
-    height='18'
+    width='1.125rem'
+    height='1.125rem'
     viewBox='0 0 18 18'
     fill='none'
     xmlns='http://www.w3.org/2000/svg'

--- a/packages/common/src/assets/svg/ShopIcon.tsx
+++ b/packages/common/src/assets/svg/ShopIcon.tsx
@@ -1,7 +1,7 @@
 const ShopIcon = () => (
   <svg
-    width='20'
-    height='20'
+    width='1.25rem'
+    height='1.25rem'
     viewBox='0 0 20 20'
     fill='none'
     xmlns='http://www.w3.org/2000/svg'

--- a/packages/common/src/components/Header/style.ts
+++ b/packages/common/src/components/Header/style.ts
@@ -31,10 +31,6 @@ export const Title = styled.span`
   color: #444872;
   font-weight: 700;
   margin-left: 0.9375rem;
-
-  @media (max-width: 320px) {
-    font-size: 0.5rem;
-  }
 `;
 
 export const MenuNav = styled.div`
@@ -44,7 +40,7 @@ export const MenuNav = styled.div`
 
 export const MenuStrokeItemWrapper = styled(Link)<{ isActive?: boolean }>`
   @media (max-width: 300px) {
-    width: 1.875rem;
+    width: 30px;
   }
   ${({ isActive, theme }) => {
     const activeColor = isActive ? theme.color.primary : theme.color.black;
@@ -76,7 +72,7 @@ export const MenuStrokeItemWrapper = styled(Link)<{ isActive?: boolean }>`
 
 export const MenuFillItemWrapper = styled(Link)<{ isActive?: boolean }>`
   @media (max-width: 300px) {
-    width: 1.875rem;
+    width: 30px;
   }
   ${({ isActive, theme }) => {
     const activeColor = isActive ? theme.color.primary : theme.color.black;

--- a/packages/common/src/components/Header/style.ts
+++ b/packages/common/src/components/Header/style.ts
@@ -15,7 +15,10 @@ export const HeaderContainer = styled.div`
   align-items: center;
   justify-content: space-between;
 
-  @media (max-width: 650px) {
+  @media (max-width: 1240px) {
+    width: calc(100vw - 12.5rem);
+  }
+  @media ${({ theme }) => theme.breakPoint[600]} {
     width: calc(100vw - 3rem);
   }
 `;
@@ -38,14 +41,12 @@ export const MenuNav = styled.div`
   gap: ${({ role }) => (role === 'admin' ? '1.5rem' : '2.25rem')};
 `;
 
-
 export const MenuStrokeItemWrapper = styled(Link)<{ isActive?: boolean }>`
   @media (max-width: 300px) {
     width: 30px;
   }
   ${({ isActive, theme }) => {
     const activeColor = isActive ? theme.color.primary : theme.color.black;
-
     const hoverColor = theme.color.primary;
     return `
       display: flex;
@@ -72,14 +73,12 @@ export const MenuStrokeItemWrapper = styled(Link)<{ isActive?: boolean }>`
   }}
 `;
 
-
 export const MenuFillItemWrapper = styled(Link)<{ isActive?: boolean }>`
   @media (max-width: 300px) {
     width: 30px;
   }
   ${({ isActive, theme }) => {
     const activeColor = isActive ? theme.color.primary : theme.color.black;
-
     const hoverColor = theme.color.primary;
     return `
       display: flex;

--- a/packages/common/src/components/Header/style.ts
+++ b/packages/common/src/components/Header/style.ts
@@ -14,6 +14,10 @@ export const HeaderContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
+
+  @media (max-width: 650px) {
+    width: calc(100vw - 3rem);
+  }
 `;
 
 export const LogoContainer = styled(Link)`
@@ -27,6 +31,10 @@ export const Title = styled.span`
   color: #444872;
   font-weight: 700;
   margin-left: 0.9375rem;
+
+  @media (max-width: 320px) {
+    font-size: 0.5rem;
+  }
 `;
 
 export const MenuNav = styled.div`
@@ -35,6 +43,9 @@ export const MenuNav = styled.div`
 `;
 
 export const MenuStrokeItemWrapper = styled(Link)<{ isActive?: boolean }>`
+  @media (max-width: 300px) {
+    width: 1.875rem;
+  }
   ${({ isActive, theme }) => {
     const activeColor = isActive ? theme.color.primary : theme.color.black;
     const hoverColor = theme.color.primary;
@@ -64,6 +75,9 @@ export const MenuStrokeItemWrapper = styled(Link)<{ isActive?: boolean }>`
 `;
 
 export const MenuFillItemWrapper = styled(Link)<{ isActive?: boolean }>`
+  @media (max-width: 300px) {
+    width: 1.875rem;
+  }
   ${({ isActive, theme }) => {
     const activeColor = isActive ? theme.color.primary : theme.color.black;
     const hoverColor = theme.color.primary;
@@ -78,7 +92,7 @@ export const MenuFillItemWrapper = styled(Link)<{ isActive?: boolean }>`
         rect, path {fill:${activeColor};}
       }
 
-      &:hover{
+        &:hover{
         span,
         & svg{
           color:${hoverColor};


### PR DESCRIPTION
## 개요 💡

> Header 반응형 작업 제작하였습니다.

## 작업내용 ⌨️
![](https://cdn.discordapp.com/attachments/956190154454876183/1178206355652350052/image.png?ex=65754d2d&is=6562d82d&hm=bfa9f43e680212379e771e202ccb5c6ffcf58aa5bef65709e5ccc9b753ef1488&)

![](https://cdn.discordapp.com/attachments/956190154454876183/1178206515983831122/image.png?ex=65754d53&is=6562d853&hm=ae5acec4a207f8ab91e435d63137772992fd93110bc51e900ca84ac6cf368f94&)

> Header Menu 선택 창에서 모바일 앱 버전으로 하기 위해서 menu container에 일정 px 미만이면 width 설정하였습니다.

## 관련 issue 🤯
 > 300px 미만일 경우에는 rem으로 설정을 하지 않고 px로 설정을 한 이유는 모바일 앱에서 고정적인 container을 사용하기 때문에 그에 따른 다른 컴포넌트에서도 피해가 가기 떄문입니다. 


